### PR TITLE
Enhance Mailchimp Driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,20 +24,6 @@ Then run:
 composer require besmarteeinc/laravel-mailchimp-driver
 ```
 
-In your `services.php` config file, add the following configuration:
-
-```php
-// config/services.php
-
-return [
-    // ...
-
-    'mailchimp' => [
-        'secret' => env('MAILCHIMP_KEY'),
-    ],
-];
-```
-
 Then set your `MAILCHIMP_KEY` in your env.
 ```php
 MAILCHIMP_KEY=<your key>
@@ -54,6 +40,7 @@ return [
 
         'mailchimp' => [
             'transport' => 'mailchimp',
+            'secret' => env('MAILCHIMP_KEY'),
         ],
 
     ],

--- a/src/MailchimpServiceProvider.php
+++ b/src/MailchimpServiceProvider.php
@@ -15,11 +15,11 @@ class MailchimpServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        Mail::extend('mailchimp', function () {
+        Mail::extend('mailchimp', function ($config) {
             $client = new ApiClient;
-            $client->setApiKey(config('mailchimp.secret'));
+            $client->setApiKey($config['secret'] ?? '');
 
-            return new MailchimpTransport($client);
+            return new MailchimpTransport($client, $config);
         });
     }
 }

--- a/src/MailchimpTransport.php
+++ b/src/MailchimpTransport.php
@@ -1,12 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BeSmarteeInc;
 
 use MailchimpTransactional\ApiClient;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractTransport;
 use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\MessageConverter;
+use Symfony\Component\Mime\Part\DataPart;
 
 class MailchimpTransport extends AbstractTransport
 {
@@ -15,6 +19,7 @@ class MailchimpTransport extends AbstractTransport
      */
     public function __construct(
         protected ApiClient $client,
+        protected array $configs = []
     ) {
         parent::__construct();
     }
@@ -26,19 +31,127 @@ class MailchimpTransport extends AbstractTransport
     {
         $email = MessageConverter::toEmail($message->getOriginalMessage());
 
-        $response = $this->client->messages->send(['message' => [
-            'from_email' => $email->getFrom()[0]->getAddress(),
-            'to' => collect($email->getTo())->map(function (Address $email) {
-                return ['email' => $email->getAddress(), 'type' => 'to'];
-            })->all(),
-            'subject' => $email->getSubject(),
-            'html' => $email->getHtmlBody(),
-        ]]);
+        $response = $this->client->messages->send(['message' => $this->buildMessageData($email)]);
 
         if (optional($response)[0]) {
             $message->getOriginalMessage()->getHeaders()->addHeader('X-Message-ID', $response[0]?->_id);
             $message->getOriginalMessage()->getHeaders()->addHeader('X-Message-Status', $response[0]?->status);
         }
+    }
+
+    protected function buildMessageData(Email $email): array
+    {
+
+        $messageData = array_merge($this->determineBaseMessageConfig(), [
+            'to' => $this->determineRecipients($email),
+            'subject' => $email->getSubject(),
+            'html' => $email->getHtmlBody(),
+        ]);
+
+        $messageData = array_merge($messageData, $this->determineFrom($email));
+
+        $mailHeaders = $this->determineMailHeaders($email);
+
+        if (! empty($mailHeaders)) {
+            $messageData['headers'] = $mailHeaders;
+        }
+
+        $attachments = $this->determineAttachments($email);
+
+        if (! empty($attachments)) {
+            $messageData['attachments'] = $attachments;
+        }
+
+        return $messageData;
+    }
+
+    protected function determineBaseMessageConfig(): array
+    {
+        $messageData = [];
+        isset($this->configs['tags']) && $messageData['tags'] = $this->configs['tags'];
+        isset($this->configs['tracking_domain']) && $messageData['tracking_domain'] = $this->configs['tracking_domain'];
+        isset($this->configs['inline_css']) && $messageData['inline_css'] = $this->configs['inline_css'];
+        isset($this->configs['track_clicks']) && $messageData['track_clicks'] = $this->configs['track_clicks'];
+        isset($this->configs['track_opens']) && $messageData['track_opens'] = $this->configs['track_opens'];
+
+        return $messageData;
+    }
+
+    protected function determineMailHeaders(Email $email): array
+    {
+        $headers = [];
+
+        $replyTo = $email->getReplyTo()[0] ?? null;
+
+        if ($replyTo) {
+            $headers['Reply-To'] = $replyTo->getAddress();
+        }
+
+        return $headers;
+    }
+
+    protected function determineFrom(Email $email): array
+    {
+        $from = $email->getFrom()[0] ?? null;
+
+        return array_filter([
+            'from_email' => $from?->getAddress(),
+            'from_name' => $from?->getName(),
+        ]);
+    }
+
+    protected function determineRecipients(Email $email): array
+    {
+        $toEmails = collect($email->getTo())
+            ->map(fn (Address $address) => $this->transformAddress($address));
+
+        $ccEmails = collect($email->getCc())
+            ->map(fn (Address $address) => $this->transformAddress($address, 'cc'));
+
+        $bccEmails = collect($email->getBcc())
+            ->map(fn (Address $address) => $this->transformAddress($address, 'bcc'));
+
+        return $toEmails->merge($ccEmails)->merge($bccEmails)->values()->all();
+    }
+
+    protected function determineAttachments(Email $email): array
+    {
+        $attachments = $email->getAttachments();
+
+        return collect($attachments)->map(function (DataPart $attachment) {
+            return $this->transformAttachment($attachment);
+        })->values()->all();
+    }
+
+    /**
+     * @return array{type: string, email: string, name: string}
+     */
+    protected function transformAddress(Address $address, ?string $type = null): array
+    {
+        $data = [
+            'type' => $type ?? 'to',
+            'email' => $address->getAddress(),
+        ];
+
+        $name = $address->getName();
+
+        if (! empty($name)) {
+            $data['name'] = $name;
+        }
+
+        return $data;
+    }
+
+    /**
+     * @return array{type: string, name: string, content: string}
+     */
+    protected function transformAttachment(DataPart $attachment): array
+    {
+        return [
+            'type' => $attachment->getContentType(),
+            'name' => $attachment->getName(),
+            'content' => base64_encode($attachment->getBody()),
+        ];
     }
 
     /**

--- a/tests/MailchimpTransportTest.php
+++ b/tests/MailchimpTransportTest.php
@@ -10,7 +10,12 @@ class TestMailable extends Mailable
 {
     public function build()
     {
-        return $this->from('no-reply@besmartee.com')->html('Hello World');
+        return $this->from('dev@besmartee.com')
+            ->html('Hello World')
+            ->cc('cc@besmartee.com', 'CC BeSmartee')
+            ->bcc('bcc@besmartee.com')
+            ->replyTo('reply@besmartee.com')
+            ->attachData('file content', 'test.txt', ['mine' => 'text/plain']);
     }
 }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -20,7 +20,10 @@ class TestCase extends Orchestra
 
     public function getEnvironmentSetUp($app)
     {
-        $app['config']->set('mail.driver', 'mailchimp');
-        $app['config']->set('mailchimp.secret', env('MAILCHIMP_SECRET')); // dummy account
+        $app['config']->set('mail.default', 'mailchimp');
+        $app['config']->set('mail.mailers.mailchimp', [
+            'transport' => 'mailchimp',
+            'secret' => env('MAILCHIMP_SECRET'),
+        ]);
     }
 }


### PR DESCRIPTION
Just my personal work to enhance this package. Feel free to check it out or ignore it

Check list:
- [x] Support address name
- [x] Support Attachments
- [x] Support CC and BCC
- [x] Change mail configuration to new style.  

p/s: In the Hyperion, I do not agree to send mail via `backend/modules/Notification/Services/MailchimpClient.php`
<img width="1639" alt="Screenshot 2025-02-11 at 17 22 37" src="https://github.com/user-attachments/assets/3dc18c88-da96-4163-9b72-faa2b20bf5af" />

I would love to use this package to consume mail driver. 

For now, it helps us easier to setup all emails sent to one address (https://www.amitmerchant.com/send-emails-to-a-single-test-email-address-for-test-environments-in-laravel/). 

It also supports us to use best practices of consuming email within Laravel https://laravel.com/docs/11.x/mail#generating-mailables. 

And we can also use local mail driver such as MailHog to reduce request to the real mail service (Mailchimp/Mandrill)